### PR TITLE
Change the domain name to nycu

### DIFF
--- a/nctu-dorm-login.sh
+++ b/nctu-dorm-login.sh
@@ -9,7 +9,7 @@ read PASSWD
 stty echo
 echo
 
-if [ -n "$(curl -d "username=$ACCOUNT&userpwd=$PASSWD" -v 'https://dorm.nctu.edu.tw/cgi-bin/ace_web_auth.cgi?web_jumpto=&orig_referer=http://detectportal.firefox.com/success.txt' 2>&1 | grep -F '/login_online_detail.php?show_portal=1')" ];then
+if [ -n "$(curl -d "username=$ACCOUNT&userpwd=$PASSWD" -v 'https://dorm.nycu.edu.tw/cgi-bin/ace_web_auth.cgi?web_jumpto=&orig_referer=http://detectportal.firefox.com/success.txt' 2>&1 | grep -F '/login_online_detail.php?show_portal=1')" ];then
 	echo 'Success'
 else
 	echo 'Failed'

--- a/nctu-dorm-state.sh
+++ b/nctu-dorm-state.sh
@@ -3,7 +3,7 @@
 printf 'Date\t\tAll\tTx\tRx (Byte)'
 printf '\nToday\t'
 
-curl 'https://dorm.nctu.edu.tw/login_online_detail.php?login_page=/auth_entry.php?authmeth=7' 2>&1 | while read -r line;do
+curl 'https://dorm.nycu.edu.tw/login_online_detail.php?login_page=/auth_entry.php?authmeth=7' 2>&1 | while read -r line;do
 	if [ -n "$(echo \"$line\" | grep 本次)" ];then
 		continue
 	elif [ -n "$(echo \"$line\" | grep alignCenter)" ];then


### PR DESCRIPTION
NCTU has adopted the new domain name since 2021/2/1. 
Tested on my machine, successfully logged in.